### PR TITLE
Added print statement to prompt user if no angles probability file will be written.

### DIFF
--- a/param.cpp
+++ b/param.cpp
@@ -997,6 +997,7 @@ int bioem_param::CalculateGridsParam(
   {
       printf ("Important, if you want BioEM to output angle probabilities after it has finished, you need to set WRITE_PROB_ANGLES to an integer in the parameter file. These probilities are needed for subsequent rounds of BioEM.\n");
   }
+  printf ("The number of angle probabilities written will be %d.", param_device.writeAngles);
 
   if (!doquater)
   {

--- a/param.cpp
+++ b/param.cpp
@@ -409,6 +409,7 @@ int bioem_param::readParameters(const char *fileinput)
              0) // Key word if writing down each angle probabilities
     {
       token = strtok(NULL, " ");
+      printf ("Warning, will not write angle probabilities after BioEM is finished. If this is not intended please set WRITE_PROB_ANGLES to an integer in the parameter file.")
       param_device.writeAngles = int(atoi(token));
       if (param_device.writeAngles < 0)
       {

--- a/param.cpp
+++ b/param.cpp
@@ -409,8 +409,8 @@ int bioem_param::readParameters(const char *fileinput)
              0) // Key word if writing down each angle probabilities
     {
       token = strtok(NULL, " ");
-      printf ("Warning, will not write angle probabilities after BioEM is finished. If this is not intended please set WRITE_PROB_ANGLES to an integer in the parameter file.")
       param_device.writeAngles = int(atoi(token));
+      printf("parameter write angles %d",param_device.writeAngles);
       if (param_device.writeAngles < 0)
       {
         myError("Negative WRITE_PROB_ANGLES");
@@ -993,6 +993,11 @@ int bioem_param::CalculateGridsParam(
   // **************** Routine that pre-calculates Orientation
   // Grids**********************
   // ************************************************************************************
+  // check if no angles will be output and prompt the user if this was their intention. 
+  if ( param_device.writeAngles == 0) 
+  {
+      printf ("Important, if you want BioEM to output angle probabilities after it has finished, you need to set WRITE_PROB_ANGLES to an integer in the parameter file. These probilities are needed for subsequent rounds of BioEM.\n");
+  }
 
   if (!doquater)
   {

--- a/param.cpp
+++ b/param.cpp
@@ -995,9 +995,9 @@ int bioem_param::CalculateGridsParam(
   // check if no angles will be output and prompt the user if this was their intention. 
   if ( param_device.writeAngles == 0) 
   {
-      printf ("Important, if you want BioEM to output angle probabilities after it has finished, you need to set WRITE_PROB_ANGLES to an integer in the parameter file. These probilities are needed for subsequent rounds of BioEM.\n");
+      printf ("\nImportant, if you want BioEM to output angle probabilities after it has finished, you need to set WRITE_PROB_ANGLES to an integer in the parameter file. These probilities are needed for subsequent rounds of BioEM.\n");
   }
-  printf ("The number of angle probabilities written will be %d.", param_device.writeAngles);
+  printf ("Number of angle probabilities %d.\n\n", param_device.writeAngles);
 
   if (!doquater)
   {

--- a/param.cpp
+++ b/param.cpp
@@ -410,7 +410,6 @@ int bioem_param::readParameters(const char *fileinput)
     {
       token = strtok(NULL, " ");
       param_device.writeAngles = int(atoi(token));
-      printf("parameter write angles %d",param_device.writeAngles);
       if (param_device.writeAngles < 0)
       {
         myError("Negative WRITE_PROB_ANGLES");


### PR DESCRIPTION
I ran a long job and forgot to add WRITE_PROB_ANGLES to the parameter file. Since I'm not very familiar with the code it took me some time to figure out what I'd done wrong. I've added a simple if statement to params.cpp to prompt the user if they've forgotten to include this parameter. If you think this would be helpful please feel free to merge this PR.